### PR TITLE
docs(profile): add `primitives` and `consensus` crate rows to org community table

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,7 +24,6 @@ bitcoin | [bitcoin](https://crates.io/crates/bitcoin) | [rust-bitcoin](https://g
 bitcoinconsensus | [bitcoinconsensus](https://crates.io/crates/bitcoin-consensus-encoding) | [rust-bitcoinconsensus](https://github.com/rust-bitcoin/rust-bitcoinconsensus)
 bech32 | [bech32](https://crates.io/crates/bech32) | [rust-bech32](https://github.com/rust-bitcoin/rust-bech32)
 chacha20_poly1305 | [chacha20-poly1305](https://crates.io/crates/chacha20-poly1305) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
-consensus | [consensus-encoding](https://crates.io/crates/consensus-encoding) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 hashes | [bitcoin_hashes](https://crates.io/crates/bitcoin_hashes) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 hex | [hex-conservative](https://crates.io/crates/hex-conservative) | [hex-conservative](https://github.com/rust-bitcoin/hex-conservative)
 internals | [bitcoin-internals](https://crates.io/crates/bitcoin-internals) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,14 +21,16 @@ Name | Crate | Repository
 ---|---|---
 base58 | [base58ck](https://crates.io/crates/base58ck) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 bitcoin | [bitcoin](https://crates.io/crates/bitcoin) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
-bitcoinconsensus | [bitcoinconsensus](https://crates.io/crates/bitcoinconsensus) | [rust-bitcoinconsensus](https://github.com/rust-bitcoin/rust-bitcoinconsensus)
+bitcoinconsensus | [bitcoinconsensus](https://crates.io/crates/bitcoin-consensus-encoding) | [rust-bitcoinconsensus](https://github.com/rust-bitcoin/rust-bitcoinconsensus)
 bech32 | [bech32](https://crates.io/crates/bech32) | [rust-bech32](https://github.com/rust-bitcoin/rust-bech32)
 chacha20_poly1305 | [chacha20-poly1305](https://crates.io/crates/chacha20-poly1305) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
+consensus | [consensus-encoding](https://crates.io/crates/consensus-encoding) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 hashes | [bitcoin_hashes](https://crates.io/crates/bitcoin_hashes) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 hex | [hex-conservative](https://crates.io/crates/hex-conservative) | [hex-conservative](https://github.com/rust-bitcoin/hex-conservative)
 internals | [bitcoin-internals](https://crates.io/crates/bitcoin-internals) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 io | [bitcoin-io](https://crates.io/crates/bitcoin-io) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 ordered | [ordered](https://crates.io/crates/ordered) | [rust-ordered](https://github.com/rust-bitcoin/rust-ordered)
+primitives | [bitcoin-primitives](https://crates.io/crates/bitcoin-primitives) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 secp256k1 | [secp256k1](https://crates.io/crates/secp256k1) | [rust-secp256k1](https://github.com/rust-bitcoin/rust-secp256k1)
 units | [bitcoin-units](https://crates.io/crates/bitcoin-units) | [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
 


### PR DESCRIPTION
Adds missing entries to the organization profile table:

- primitives → crates.io: bitcoin-primitives | repo: rust-bitcoin/rust-bitcoin
- consensus → crates.io: consensus-encoding | repo: rust-bitcoin/rust-bitcoin

Fixes rust-bitcoin/rust-bitcoin#5055.
